### PR TITLE
Allow dispatching debug workflow manually

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ on:
       - master
       - develop
       - releases/*
+  workflow_dispatch:
         
 env:
   FPC_URL: 'gitlab'


### PR DESCRIPTION
Simply adds `workflow_dispatch` option to allow workflow to be run manually from "Actions" page.